### PR TITLE
Updates PostSharp references to 4.0.36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,10 @@ ipch/
 # ReSharper is a .NET coding add-in
 _ReSharper*
 
+# NCrunch is a .NET test runner
+*.ncrunchproject
+*.ncrunchsolution
+
 # Installshield output folder
 [Ee]xpress
 

--- a/NullGuard.PostSharp/NullGuard.PostSharp.csproj
+++ b/NullGuard.PostSharp/NullGuard.PostSharp.csproj
@@ -12,10 +12,10 @@
     <AssemblyName>NullGuard.PostSharp</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <DontImportPostSharp>True</DontImportPostSharp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <BuildPackage>true</BuildPackage>
+    <DontImportPostSharp>True</DontImportPostSharp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,7 +36,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PostSharp">
-      <HintPath>..\packages\PostSharp.2.1.7.28\lib\net20\PostSharp.dll</HintPath>
+      <Private>True</Private>
+      <HintPath>..\packages\PostSharp.4.0.36\lib\net35-client\PostSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -59,6 +60,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="..\packages\PostSharp.4.0.36\tools\PostSharp.targets" Condition="Exists('..\packages\PostSharp.4.0.36\tools\PostSharp.targets')" />
+  <Target Name="EnsurePostSharpImported" BeforeTargets="BeforeBuild" Condition="'$(PostSharp30Imported)' == ''">
+    <Error Condition="!Exists('..\packages\PostSharp.4.0.36\tools\PostSharp.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://www.postsharp.net/links/nuget-restore." />
+    <Error Condition="Exists('..\packages\PostSharp.4.0.36\tools\PostSharp.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://www.postsharp.net/links/nuget-restore." />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NullGuard.PostSharp/Properties/AssemblyInfo.cs
+++ b/NullGuard.PostSharp/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.0.1.0")]
-[assembly: AssemblyFileVersion("0.0.1.0")]
-[assembly: AssemblyInformationalVersion("0.1.0")]
+[assembly: AssemblyVersion("0.0.2.0")]
+[assembly: AssemblyFileVersion("0.0.2.0")]
+[assembly: AssemblyInformationalVersion("0.2.0")]

--- a/NullGuard.PostSharp/packages.config
+++ b/NullGuard.PostSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="PostSharp" version="2.1.7.28" targetFramework="net40" />
+  <package id="PostSharp" version="4.0.36" targetFramework="net40" />
 </packages>

--- a/NullGuard.sln.DotSettings
+++ b/NullGuard.sln.DotSettings
@@ -258,4 +258,5 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 &#xD;
 &lt;/Patterns&gt;&#xD;
 </s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	</wpf:ResourceDictionary>

--- a/NullGuard.sln.DotSettings
+++ b/NullGuard.sln.DotSettings
@@ -258,5 +258,4 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 &#xD;
 &lt;/Patterns&gt;&#xD;
 </s:String>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	</wpf:ResourceDictionary>

--- a/Tests/EnsureNonNullAspectFacts.cs
+++ b/Tests/EnsureNonNullAspectFacts.cs
@@ -138,6 +138,15 @@ namespace Tests
         }
     }
 
+    public class InheritanceTests
+    {
+        [Fact]
+        public void ConstraintOnProtectedConstructorIsApplied()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SampleDerivedClass(null));
+        }
+    }
+
     [EnsureNonNullAspect]
     public class SampleClass
     {

--- a/Tests/SampleBaseClass.cs
+++ b/Tests/SampleBaseClass.cs
@@ -1,0 +1,24 @@
+﻿using NullGuard.PostSharp;
+
+namespace Tests
+{
+    public abstract class SampleBaseClass
+    {
+        public int BaseArgumentLength { get; private set; }
+
+        [EnsureNonNullAspect(ValidationFlags.All)]
+        protected SampleBaseClass(string notNull)
+        {
+            BaseArgumentLength = notNull.Length;
+        }
+    }
+
+    public class SampleDerivedClass : SampleBaseClass
+    {
+        [EnsureNonNullAspect]
+        public SampleDerivedClass(string notNull)
+            : base (notNull)
+        {
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -16,6 +16,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <BuildPackage>false</BuildPackage>
+    <DontImportPostSharp>True</DontImportPostSharp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -40,8 +41,9 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="PostSharp">
-      <HintPath>..\packages\PostSharp.2.1.7.28\lib\net20\PostSharp.dll</HintPath>
+    <Reference Include="PostSharp, Version=4.0.36.0, Culture=neutral, PublicKeyToken=b13fd38b8f9c99d7, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\PostSharp.4.0.36\lib\net35-client\PostSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -59,7 +61,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NullGuard.PostSharp\NullGuard.PostSharp.csproj">
@@ -69,7 +73,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
-  <Import Project="..\packages\PostSharp.2.1.7.28\tools\PostSharp.targets" Condition="Exists('..\packages\PostSharp.2.1.7.28\tools\PostSharp.targets')" />
+  <Import Project="..\packages\PostSharp.4.0.36\tools\PostSharp.targets" Condition="Exists('..\packages\PostSharp.4.0.36\tools\PostSharp.targets')" />
+  <Target Name="EnsurePostSharpImported" BeforeTargets="BeforeBuild" Condition="'$(PostSharp30Imported)' == ''">
+    <Error Condition="!Exists('..\packages\PostSharp.4.0.36\tools\PostSharp.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://www.postsharp.net/links/nuget-restore." />
+    <Error Condition="Exists('..\packages\PostSharp.4.0.36\tools\PostSharp.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://www.postsharp.net/links/nuget-restore." />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="EnsureNonNullAspectFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SampleBaseClass.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="PostSharp" version="2.1.7.28" targetFramework="net40-Client" />
+  <package id="PostSharp" version="4.0.36" targetFramework="net40-Client" />
   <package id="xunit" version="1.9.1" targetFramework="net40-Client" />
 </packages>


### PR DESCRIPTION
I wanted to use the EnsureNonNullAspect attribute with version 4.0.36 of PostSharp, but when I included the NuGet package I ended up getting a bunch of assembly binding issues reported from PostSharp.  I've forked and changed the references to the latest stable PostSharp version.

I also want to change the package version number, but I wasn't sure exactly what to update it to.  For now I've just incremented it but let me know if there's a better change to make here.

My new test was to find out why the attribute wasn't applying to a protected constructor, so I'm including it here to demonstrate usage for protected constructors.
